### PR TITLE
Add thread-pool implementation to read byte stream 

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/BallerinaByteBlockInputStream.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/BallerinaByteBlockInputStream.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package io.ballerina.stdlib.data.xmldata.xml;
+package io.ballerina.stdlib.data.xmldata.io;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.async.Callback;

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderTask.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderTask.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.stdlib.data.xmldata.io;
+
+import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.Future;
+import io.ballerina.runtime.api.types.MethodType;
+import io.ballerina.runtime.api.types.ObjectType;
+import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.stdlib.data.xmldata.utils.DiagnosticErrorCode;
+import io.ballerina.stdlib.data.xmldata.utils.DiagnosticLog;
+import io.ballerina.stdlib.data.xmldata.xml.XmlParser;
+
+import java.io.InputStreamReader;
+import java.util.function.Consumer;
+
+/**
+ * This class will read data from a Ballerina Stream of byte blocks, in non-blocking manner.
+ *
+ * @since 0.1.0
+ */
+public class DataReaderTask implements Runnable {
+
+    private static final String METHOD_NAME_NEXT = "next";
+    private static final String METHOD_NAME_CLOSE = "close";
+
+    private final Environment env;
+    private final BObject iteratorObj;
+    private final Future future;
+    private final BTypedesc typed;
+
+    public DataReaderTask(Environment env, BObject iteratorObj, Future future, BTypedesc typed) {
+        this.env = env;
+        this.iteratorObj = iteratorObj;
+        this.future = future;
+        this.typed = typed;
+    }
+
+    static MethodType resolveNextMethod(BObject iterator) {
+        MethodType method = getMethodType(iterator, METHOD_NAME_NEXT);
+        if (method != null) {
+            return method;
+        }
+        throw new IllegalStateException("next method not found in the iterator object");
+    }
+
+    static MethodType resolveCloseMethod(BObject iterator) {
+        return getMethodType(iterator, METHOD_NAME_CLOSE);
+    }
+
+    private static MethodType getMethodType(BObject iterator, String methodNameClose) {
+        ObjectType objectType = (ObjectType) TypeUtils.getReferredType(iterator.getOriginalType());
+        MethodType[] methods = objectType.getMethods();
+        // Assumes compile-time validation of the iterator object
+        for (MethodType method : methods) {
+            if (method.getName().equals(methodNameClose)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void run() {
+        DataReaderTask.ResultConsumer<Object> resultConsumer = new DataReaderTask.ResultConsumer<>(future);
+        try (var byteBlockSteam = new BallerinaByteBlockInputStream(env, iteratorObj, resolveNextMethod(iteratorObj),
+                                                                    resolveCloseMethod(iteratorObj), resultConsumer)) {
+            Object result = XmlParser.parse(new InputStreamReader(byteBlockSteam), typed.getDescribingType());
+            future.complete(result);
+        } catch (Exception e) {
+            future.complete(DiagnosticLog.error(DiagnosticErrorCode.STREAM_BROKEN, e.getMessage()));
+        }
+    }
+
+    /**
+     * This class will hold module related utility functions.
+     *
+     * @param <T>    The type of the result
+     * @param future The future to complete
+     * @since 0.1.0
+     */
+    public record ResultConsumer<T>(Future future) implements Consumer<T> {
+
+        @Override
+        public void accept(T t) {
+            future.complete(t);
+        }
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderTask.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderTask.java
@@ -65,12 +65,12 @@ public class DataReaderTask implements Runnable {
         return getMethodType(iterator, METHOD_NAME_CLOSE);
     }
 
-    private static MethodType getMethodType(BObject iterator, String methodNameClose) {
+    private static MethodType getMethodType(BObject iterator, String methodName) {
         ObjectType objectType = (ObjectType) TypeUtils.getReferredType(iterator.getOriginalType());
         MethodType[] methods = objectType.getMethods();
         // Assumes compile-time validation of the iterator object
         for (MethodType method : methods) {
-            if (method.getName().equals(methodNameClose)) {
+            if (method.getName().equals(methodName)) {
                 return method;
             }
         }

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.stdlib.data.xmldata.io;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread pool for data reader.
+ *
+ * @since 0.1.0
+ */
+public class DataReaderThreadPool {
+
+    // TODO : Make this configurable, in Ballerina Library.
+    public static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(0, 20, 60L, TimeUnit.SECONDS,
+                                                                                  new SynchronousQueue<>(),
+                                                                                  new DataThreadFactory());
+
+    /**
+     * Thread factory for data reader.
+     */
+    static class DataThreadFactory implements ThreadFactory {
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread ballerinaSql = new Thread(runnable);
+            ballerinaSql.setName("bal-data-xmldata-thread");
+            return ballerinaSql;
+        }
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
@@ -42,9 +42,9 @@ public class DataReaderThreadPool {
 
         @Override
         public Thread newThread(Runnable runnable) {
-            Thread ballerinaSql = new Thread(runnable);
-            ballerinaSql.setName("bal-data-xmldata-thread");
-            return ballerinaSql;
+            Thread balThread = new Thread(runnable);
+            balThread.setName("bal-data-xmldata-thread");
+            return balThread;
         }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 public class DataReaderThreadPool {
 
     // TODO : Make this configurable, in Ballerina Library.
-    public static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(0, 20, 60L, TimeUnit.SECONDS,
+    public static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(0, 50, 60L, TimeUnit.SECONDS,
                                                                                   new SynchronousQueue<>(),
                                                                                   new DataThreadFactory());
 

--- a/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
+++ b/native/src/main/java/io/ballerina/stdlib/data/xmldata/io/DataReaderThreadPool.java
@@ -31,9 +31,12 @@ import java.util.concurrent.TimeUnit;
 public class DataReaderThreadPool {
 
     // TODO : Make this configurable, in Ballerina Library.
-    public static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(0, 50, 60L, TimeUnit.SECONDS,
-                                                                                  new SynchronousQueue<>(),
-                                                                                  new DataThreadFactory());
+    private static final int CORE_POOL_SIZE = 0;
+    private static final int MAX_POOL_SIZE = 50;
+    private static final long KEEP_ALIVE_TIME = 60L;
+    private static final String THREAD_NAME = "bal-data-xmldata-thread";
+    public static final ExecutorService EXECUTOR_SERVICE = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE,
+            KEEP_ALIVE_TIME, TimeUnit.SECONDS, new SynchronousQueue<>(), new DataThreadFactory());
 
     /**
      * Thread factory for data reader.
@@ -43,7 +46,7 @@ public class DataReaderThreadPool {
         @Override
         public Thread newThread(Runnable runnable) {
             Thread balThread = new Thread(runnable);
-            balThread.setName("bal-data-xmldata-thread");
+            balThread.setName(THREAD_NAME);
             return balThread;
         }
     }


### PR DESCRIPTION
## Purpose

This pull request adds a thread-pool implementation to read byte streams. It includes the addition of two new classes: `DataReaderThreadPool` and `DataReaderTask`. The `DataReaderThreadPool` class provides a thread pool for data readers, while the `DataReaderTask` class reads data from a Ballerina stream of byte blocks in a non-blocking manner. These additions enhance the performance and efficiency of reading byte streams in the application.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
